### PR TITLE
Fix: inner_value_change not called on slider interaction

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -9905,10 +9905,10 @@ LGraphNode.prototype.executeAction = function(action)
                     }
 					break;
 				case "slider":
-					var range = w.options.max - w.options.min;
+					var old_value = w.value;
 					var nvalue = Math.clamp((x - 15) / (widget_width - 30), 0, 1);
 					w.value = w.options.min + (w.options.max - w.options.min) * nvalue;
-					if (w.callback) {
+					if (old_value != w.value) {
 						setTimeout(function() {
 							inner_value_change(w, w.value);
 						}, 20);


### PR DESCRIPTION
Why:

- unifies the change handling between slider and number widgets
- makes it possible to have a property value automatically reflect the widget.

This change addresses the need by:

- Updating the change detection

Optional details:

Cherry picked from https://github.com/jagenjo/litegraph.js/pull/297